### PR TITLE
feat: ActionTextField

### DIFF
--- a/src/controls/ActionTextField.qml
+++ b/src/controls/ActionTextField.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.12
+import QtQuick.Layouts 1.12
+import QtQuick.Controls 2.12
+import FishUI 1.0 as FishUI
+
+TextField {
+    id: control
+    
+    property list<QtObject> rightActions
+    
+    rightPadding: FishUI.Units.smallSpacing + rightActionsRow.width
+    Row {
+        id: rightActionsRow
+        padding: FishUI.Units.smallSpacing
+        layoutDirection: Qt.RightToLeft
+        anchors.right: parent.right
+        anchors.rightMargin: FishUI.Units.smallSpacing
+        anchors.verticalCenter: parent.verticalCenter
+        height: control.implicitHeight - 2 * FishUI.Units.smallSpacing
+        Repeater {
+            model: control.rightActions
+            Icon {
+                implicitWidth: FishUI.Units.iconSizes.small
+                implicitHeight: FishUI.Units.iconSizes.small
+   
+                anchors.verticalCenter: parent.verticalCenter
+   
+                source: modelData.icon.name.length > 0 ? modelData.icon.name : modelData.icon.source
+                visible: modelData.visible
+                enabled: modelData.enabled
+                MouseArea {
+                    id: actionArea
+                    anchors.fill: parent
+                    onClicked: modelData.trigger()
+                    cursorShape: Qt.PointingHandCursor
+                }
+            }
+        }
+    }
+    
+}

--- a/src/controls/ActionTextField.qml
+++ b/src/controls/ActionTextField.qml
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 CutefishOS Team.
+ *
+ * Author:    ChungZH <chungzh07@gmail.com>    
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import QtQuick 2.12
 import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.12

--- a/src/controls/qmldir
+++ b/src/controls/qmldir
@@ -12,6 +12,7 @@ typeinfo plugins.qmltypes
 singleton Theme 1.0 Theme.qml
 singleton Units 1.0 Units.qml
 
+ActionTextField 1.0 ActionTextField
 BusyIndicator 1.0 BusyIndicator.qml
 Icon 1.0 Icon.qml
 PopupTips 1.0 PopupTips.qml

--- a/src/fishui.cpp
+++ b/src/fishui.cpp
@@ -64,6 +64,7 @@ void FishUI::registerTypes(const char *uri)
     qmlRegisterSingletonType(componentUrl(QStringLiteral("Theme.qml")), uri, 1, 0, "Theme");
     qmlRegisterSingletonType(componentUrl(QStringLiteral("Units.qml")), uri, 1, 0, "Units");
 
+    qmlRegisterType(componentUrl(QStringLiteral("ActionTextField.qml")), uri, 1, 0, "ActionTextField");    
     qmlRegisterType(componentUrl(QStringLiteral("BusyIndicator.qml")), uri, 1, 0, "BusyIndicator");
     qmlRegisterType(componentUrl(QStringLiteral("Icon.qml")), uri, 1, 0, "Icon");
     qmlRegisterType(componentUrl(QStringLiteral("PopupTips.qml")), uri, 1, 0, "PopupTips");

--- a/src/fishui.qrc
+++ b/src/fishui.qrc
@@ -24,6 +24,7 @@
         <file>images/toast/info.svg</file>
         <file>images/toast/success.svg</file>
         <file>images/toast/warn.svg</file>
+        <file alias="ActionTextField.qml">controls/ActionTextField.qml</file>
     </qresource>
     <qresource prefix="/"/>
 </RCC>


### PR DESCRIPTION
It can work:
![Peek 2021-06-26 20-10](https://user-images.githubusercontent.com/42088872/123512662-3caaff80-d6bb-11eb-9f60-7fe51863783f.gif)
```qml
import QtQuick 2.12
import QtQuick.Window 2.12
import QtQuick.Controls 2.12
import FishUI 1.0 as FishUI

Window {
    width: 640
    height: 480
    visible: true
    title: qsTr("Hello World")
    
    FishUI.ActionTextField{
        id: searchField
         
        placeholderText: "Search..."
        rightActions: [
            Action {
                icon.source: "https://raw.githubusercontent.com/cutefishos/icons/main/Crule/actions/16/edit-delete.svg"
                onTriggered: {
                    searchField.text = ""
                    searchField.accepted()
                }
            },
            Action {
                icon.source: "https://raw.githubusercontent.com/cutefishos/icons/main/Crule/actions/16/document-close.svg"
            }
        ]   
    }
}

```

Ref: https://api.kde.org/frameworks/kirigami/html/classorg_1_1kde_1_1kirigami_1_1ActionTextField.html
