### PR TITLE
feat: ComboBox indicator

### DIFF
--- a/src/fish-style/ComboBox.qml
+++ b/src/fish-style/ComboBox.qml
@@ -64,6 +64,7 @@ T.ComboBox {
         text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
         highlighted: control.highlightedIndex === index
         hoverEnabled: control.hoverEnabled
+        indicator.visible: true
     }
 
     indicator: Image {

--- a/src/fish-style/MenuItem.qml
+++ b/src/fish-style/MenuItem.qml
@@ -13,7 +13,7 @@ T.MenuItem
                                                        : Qt.rgba(0, 0, 0, 0.1)
     property color pressedColor: FishUI.Theme.darkMode ? Qt.rgba(255, 255, 255, 0.1)
                                                        : Qt.rgba(0, 0, 0, 0.2)
-
+    
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
                             implicitContentWidth + leftPadding + rightPadding)
     implicitHeight: visible ? Math.max(implicitBackgroundHeight + topInset + bottomInset,
@@ -29,18 +29,34 @@ T.MenuItem
 
     icon.color: control.enabled ? (control.highlighted ? control.FishUI.Theme.highlightColor : control.FishUI.Theme.textColor) :
                              control.FishUI.Theme.disabledTextColor
-
+    indicator: Item {
+        implicitWidth: control.implicitIndicatorWidth
+        implicitHeight: control.implicitIndicatorHeight
+        
+        anchors.right: background.left
+        anchors.verticalCenter: control.verticalCenter
+        
+        Rectangle {
+            width: 4
+            height: control.height - 2 * FishUI.Units.smallSpacing
+            anchors.centerIn: parent
+            visible: control.highlighted
+            color: FishUI.Theme.highlightColor
+            radius: 3
+        }
+    }
+    
     contentItem: IconLabel {
         readonly property real arrowPadding: control.subMenu && control.arrow ? control.arrow.width + control.spacing : 0
         readonly property real indicatorPadding: control.checkable && control.indicator ? control.indicator.width + control.spacing : 0
         leftPadding: !control.mirrored ? indicatorPadding + FishUI.Units.smallSpacing * 2 : arrowPadding
         rightPadding: control.mirrored ? indicatorPadding : arrowPadding + FishUI.Units.smallSpacing * 2
-
+    
         spacing: control.spacing
         mirrored: control.mirrored
         display: control.display
         alignment: Qt.AlignLeft
-
+    
         icon: control.icon
         text: control.text
         font: control.font

--- a/src/fish-style/MenuItem.qml
+++ b/src/fish-style/MenuItem.qml
@@ -33,8 +33,11 @@ T.MenuItem
         implicitWidth: control.implicitIndicatorWidth
         implicitHeight: control.implicitIndicatorHeight
         
-        anchors.right: background.left
-        anchors.verticalCenter: control.verticalCenter
+        anchors {
+            leftMargin: 2
+            left: background.left
+            verticalCenter: control.verticalCenter
+        }
         
         Rectangle {
             width: 4
@@ -42,7 +45,7 @@ T.MenuItem
             anchors.centerIn: parent
             visible: control.highlighted
             color: FishUI.Theme.highlightColor
-            radius: 3
+            radius: FishUI.Theme.smallRadius
         }
     }
     


### PR DESCRIPTION
![Peek 2021-07-09 17-53](https://user-images.githubusercontent.com/42088872/125061681-2865fa00-e0e0-11eb-93a8-8a1eeb7f6bba.gif)

Demo code:

```qml
import QtQuick 2.12
import QtQuick.Window 2.12
import QtQuick.Controls 2.12
import FishUI 1.0 as FishUI

Window {
    width: 640
    height: 480
    visible: true
    title: qsTr("Hello World")
    ComboBox {
        model: ["First", "Second", "Third"]
        hoverEnabled: true
        
    }
}

```

I have tried my best to copy WinUI...

![image](https://user-images.githubusercontent.com/42088872/125061708-31ef6200-e0e0-11eb-9039-85840b67f2e5.png)
