### PR TITLE
Use CMAKE_INSTALL_LIBDIR instead of hardcoded /usr/lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (MSVC)
     set(CMAKECONFIG_INSTALL_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/FishUI")
     set(CMAKE_INSTALL_PREFIX "${_VCPKG_INSTALLED_DIR}")
 else ()
-    set(CMAKECONFIG_INSTALL_DIR "/usr/lib/cmake/FishUI")
+    set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/FishUI")
 endif ()
 message(STATUS "install directory:" "${CMAKECONFIG_INSTALL_DIR}")
 


### PR DESCRIPTION
Hello ;)

I package Cutefish for the Exherbo Linux distribution.

Is it possible to use the CMAKE_INSTALL_LIBDIR variable instead of the hardcoded path?

It's forbidden for our distribution, because cross compilation (/usr/x86_64-pc-linux-gnu/lib instead of /usr/lib). And I think other distributions will have the same problem in the future, like Gentoo for example.